### PR TITLE
Support postLogout URI and native application reverse DNS filter property

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.cli</groupId>
         <artifactId>okta-cli-tools</artifactId>
-        <version>0.6.1-SNAPSHOT</version>
+        <version>0.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-cli</artifactId>

--- a/cli/src/main/java/com/okta/cli/commands/Start.java
+++ b/cli/src/main/java/com/okta/cli/commands/Start.java
@@ -47,6 +47,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
@@ -113,6 +114,11 @@ public class Start implements Callable<Integer> {
 
         // parse the `.okta.yaml` file
         OktaSampleConfig config = new DefaultSampleConfigParser().loadConfig(projectDirectory);
+        // default to SPA application
+        OpenIdConnectApplicationType applicationType = Optional.ofNullable(config.getOAuthClient().getApplicationType())
+                .map(it -> it.toUpperCase(Locale.ENGLISH))
+                .map(OpenIdConnectApplicationType::valueOf)
+                .orElse(OpenIdConnectApplicationType.BROWSER);
 
         // create the Okta application
         Client client = Clients.builder().build();
@@ -126,8 +132,9 @@ public class Start implements Callable<Integer> {
                 authorizationServer.getIssuer(),
                 authorizationServer.getId(),
                 true,
-                OpenIdConnectApplicationType.valueOf(config.getOAuthClient().getApplicationType().toUpperCase(Locale.ENGLISH)), // TODO default to SPA
+                applicationType,
                 config.getOAuthClient().getRedirectUris(),
+                config.getOAuthClient().getPostLogoutRedirectUris(),
                 config.getTrustedOrigins()
         );
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.cli</groupId>
         <artifactId>okta-cli-tools</artifactId>
-        <version>0.6.1-SNAPSHOT</version>
+        <version>0.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-cli-common</artifactId>

--- a/common/src/main/java/com/okta/cli/common/URIs.java
+++ b/common/src/main/java/com/okta/cli/common/URIs.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.cli.common;
+
+import java.net.URI;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public final class URIs {
+
+    private URIs() {}
+
+    public static String reverseDomain(String uri) {
+        URI parsedUri = URI.create(uri);
+
+        // if the parsed URI does NOT have a protocol, assume it's just a host name
+        if (parsedUri.getScheme() == null) {
+            return dnsReverse(uri);
+        }
+
+        return dnsReverse(parsedUri.getHost());
+    }
+
+    public static String baseUrlOf(String url) {
+        return URI.create(url).resolve("/").toString();
+    }
+
+    private static String dnsReverse(String host) {
+        String[] parts = host.split("\\.");
+        String reverseDomain = IntStream.rangeClosed(1, parts.length)
+                .mapToObj(i -> parts[parts.length - i])
+                .collect(Collectors.joining("."));
+
+        return reverseDomain;
+    }
+}

--- a/common/src/main/java/com/okta/cli/common/model/FilterConfigBuilder.java
+++ b/common/src/main/java/com/okta/cli/common/model/FilterConfigBuilder.java
@@ -21,6 +21,8 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class FilterConfigBuilder {
 
@@ -29,6 +31,7 @@ public class FilterConfigBuilder {
     private static final String CLI_OKTA_ISSUER_ID = "CLI_OKTA_ISSUER_ID";
     private static final String CLI_OKTA_CLIENT_ID = "CLI_OKTA_CLIENT_ID";
     private static final String CLI_OKTA_CLIENT_SECRET = "CLI_OKTA_CLIENT_SECRET";
+    private static final String CLI_OKTA_REVERSE_DOMAIN = "CLI_OKTA_REVERSE_DOMAIN";
 
     private final Map<String, String> filterValues = new HashMap<>();
 
@@ -48,7 +51,23 @@ public class FilterConfigBuilder {
 
     public FilterConfigBuilder setIssuer(String issuer) {
         filterValues.put(CLI_OKTA_ISSUER, issuer);
-        filterValues.put(CLI_OKTA_ORG_URL, URI.create(issuer).resolve("/").toString());
+        setOrgUrl(URI.create(issuer).resolve("/").toString());
+        return this;
+    }
+
+    public FilterConfigBuilder setOrgUrl(String orgUrl) {
+        filterValues.put(CLI_OKTA_ORG_URL, orgUrl);
+
+        String[] hostParts = URI.create(orgUrl).getHost().split("\\.");
+        String reverseDomain = IntStream.rangeClosed(1, hostParts.length)
+                    .mapToObj(i -> hostParts[hostParts.length - i])
+                    .collect(Collectors.joining("."));
+        setReverseDomain(reverseDomain);
+        return this;
+    }
+
+    public FilterConfigBuilder setReverseDomain(String reverseDomain) {
+        filterValues.put(CLI_OKTA_REVERSE_DOMAIN, reverseDomain);
         return this;
     }
 

--- a/common/src/main/java/com/okta/cli/common/model/OktaSampleConfig.java
+++ b/common/src/main/java/com/okta/cli/common/model/OktaSampleConfig.java
@@ -49,6 +49,7 @@ public class OktaSampleConfig {
     @Data
     public static class OAuthClient {
         private List<String> redirectUris;
+        private List<String> postLogoutRedirectUris;
         private String applicationType;
     }
 }

--- a/common/src/main/java/com/okta/cli/common/model/OktaSampleConfig.java
+++ b/common/src/main/java/com/okta/cli/common/model/OktaSampleConfig.java
@@ -50,6 +50,6 @@ public class OktaSampleConfig {
     public static class OAuthClient {
         private List<String> redirectUris;
         private List<String> postLogoutRedirectUris;
-        private String applicationType;
+        private String applicationType = "browser";
     }
 }

--- a/common/src/main/java/com/okta/cli/common/service/DefaultSampleConfigParser.java
+++ b/common/src/main/java/com/okta/cli/common/service/DefaultSampleConfigParser.java
@@ -32,7 +32,15 @@ public class DefaultSampleConfigParser implements SampleConfigParser {
             // ignore unknown properties, so we can add additional features and not break older clients
             Representer representer = new Representer();
             representer.getPropertyUtils().setSkipMissingProperties(true);
-            return new Yaml(representer).loadAs(fileInputStream, OktaSampleConfig.class);
+            OktaSampleConfig config = new Yaml(representer).loadAs(fileInputStream, OktaSampleConfig.class);
+
+            // TODO improve validation of configuration
+            if (config.getOAuthClient() == null) {
+                throw new IllegalArgumentException("Sample configuration file: '" + configFile.getAbsoluteFile() +
+                                                   "' must contain an 'oauthClient' element, see: " +
+                                                   "https://github.com/oktadeveloper/okta-cli/wiki/Create-an-Okta-Start-Samples");
+            }
+            return config;
         }
     }
 }

--- a/common/src/main/java/com/okta/cli/common/service/DefaultSampleConfigParser.java
+++ b/common/src/main/java/com/okta/cli/common/service/DefaultSampleConfigParser.java
@@ -20,27 +20,35 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.representer.Representer;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Map;
 
 public class DefaultSampleConfigParser implements SampleConfigParser {
 
-    @Override
-    public OktaSampleConfig parseConfig(File configFile) throws IOException {
-        try (FileInputStream fileInputStream = new FileInputStream(configFile.getAbsoluteFile())) {
 
-            // ignore unknown properties, so we can add additional features and not break older clients
-            Representer representer = new Representer();
-            representer.getPropertyUtils().setSkipMissingProperties(true);
-            OktaSampleConfig config = new Yaml(representer).loadAs(fileInputStream, OktaSampleConfig.class);
+    public OktaSampleConfig parseConfig(File configFile, Map<String, String> context) throws IOException {
 
-            // TODO improve validation of configuration
-            if (config.getOAuthClient() == null) {
-                throw new IllegalArgumentException("Sample configuration file: '" + configFile.getAbsoluteFile() +
-                                                   "' must contain an 'oauthClient' element, see: " +
-                                                   "https://github.com/oktadeveloper/okta-cli/wiki/Create-an-Okta-Start-Samples");
-            }
-            return config;
+        // NOTE this is not the most memory efficient way to do this, but this file is small
+        // if we need something more complex we can do that later.
+        String configFileContent = Files.readString(configFile.toPath().toAbsolutePath(), StandardCharsets.UTF_8);
+
+        // filter the file
+        configFileContent = new DefaultInterpolator().interpolate(configFileContent, context);
+
+        // ignore unknown properties, so we can add additional features and not break older clients
+        Representer representer = new Representer();
+        representer.getPropertyUtils().setSkipMissingProperties(true);
+
+        OktaSampleConfig config = new Yaml(representer).loadAs(configFileContent, OktaSampleConfig.class);
+
+        // TODO improve validation of configuration
+        if (config.getOAuthClient() == null) {
+            throw new IllegalArgumentException("Sample configuration file: '" + configFile.getAbsoluteFile() +
+                                               "' must contain an 'oauthClient' element, see: " +
+                                               "https://github.com/oktadeveloper/okta-cli/wiki/Create-an-Okta-Start-Samples");
         }
+        return config;
     }
 }

--- a/common/src/main/java/com/okta/cli/common/service/DefaultSetupService.java
+++ b/common/src/main/java/com/okta/cli/common/service/DefaultSetupService.java
@@ -167,6 +167,7 @@ public class DefaultSetupService implements SetupService {
                                       boolean interactive,
                                       OpenIdConnectApplicationType appType,
                                       List<String> redirectUris,
+                                      List<String> postLogoutRedirectUris,
                                       List<String> trustedOrigins) throws IOException {
 
         // Create new Application
@@ -183,13 +184,13 @@ public class DefaultSetupService implements SetupService {
                 ExtensibleResource clientCredsResponse;
                 switch (appType) {
                     case WEB:
-                        clientCredsResponse = oidcAppCreator.createOidcApp(client, oidcAppName, redirectUris);
+                        clientCredsResponse = oidcAppCreator.createOidcApp(client, oidcAppName, redirectUris, postLogoutRedirectUris);
                         break;
                     case NATIVE:
-                        clientCredsResponse = oidcAppCreator.createOidcNativeApp(client, oidcAppName, redirectUris);
+                        clientCredsResponse = oidcAppCreator.createOidcNativeApp(client, oidcAppName, redirectUris, postLogoutRedirectUris);
                         break;
                     case BROWSER:
-                        clientCredsResponse = oidcAppCreator.createOidcSpaApp(client, oidcAppName, redirectUris);
+                        clientCredsResponse = oidcAppCreator.createOidcSpaApp(client, oidcAppName, redirectUris, postLogoutRedirectUris);
                         break;
                     case SERVICE:
                         clientCredsResponse = oidcAppCreator.createOidcServiceApp(client, oidcAppName, redirectUris);

--- a/common/src/main/java/com/okta/cli/common/service/OidcAppCreator.java
+++ b/common/src/main/java/com/okta/cli/common/service/OidcAppCreator.java
@@ -22,11 +22,11 @@ import java.util.List;
 
 public interface OidcAppCreator {
 
-    ExtensibleResource createOidcApp(Client client, String oidcAppName, List<String> redirectUris);
+    ExtensibleResource createOidcApp(Client client, String oidcAppName, List<String> redirectUris, List<String> postLogoutRedirectUris);
 
-    ExtensibleResource createOidcNativeApp(Client client, String oidcAppName, List<String> redirectUris);
+    ExtensibleResource createOidcNativeApp(Client client, String oidcAppName, List<String> redirectUris, List<String> postLogoutRedirectUris);
 
-    ExtensibleResource createOidcSpaApp(Client client, String oidcAppName, List<String> redirectUris);
+    ExtensibleResource createOidcSpaApp(Client client, String oidcAppName, List<String> redirectUris, List<String> postLogoutRedirectUris);
 
     ExtensibleResource createOidcServiceApp(Client client, String oidcAppName, List<String> redirectUris);
 }

--- a/common/src/main/java/com/okta/cli/common/service/SampleConfigParser.java
+++ b/common/src/main/java/com/okta/cli/common/service/SampleConfigParser.java
@@ -19,18 +19,25 @@ import com.okta.cli.common.model.OktaSampleConfig;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
 
 public interface SampleConfigParser {
 
     String SAMPLE_CONFIG_PATH = ".okta/sample-config.yaml";
 
-    default OktaSampleConfig loadConfig() throws IOException {
-        return parseConfig(new File(SAMPLE_CONFIG_PATH));
-    }
-
     default OktaSampleConfig loadConfig(File localPath) throws IOException {
         return parseConfig(new File(localPath, SAMPLE_CONFIG_PATH));
     }
 
-    OktaSampleConfig parseConfig(File configFile) throws IOException;
+    default OktaSampleConfig loadConfig(File localPath, Map<String, String> context) throws IOException {
+        return parseConfig(new File(localPath, SAMPLE_CONFIG_PATH), context);
+    }
+
+    default OktaSampleConfig parseConfig(File configFile) throws IOException {
+        return parseConfig(configFile, emptyMap());
+    }
+
+    OktaSampleConfig parseConfig(File configFile, Map<String, String> context) throws IOException;
 }

--- a/common/src/main/java/com/okta/cli/common/service/SetupService.java
+++ b/common/src/main/java/com/okta/cli/common/service/SetupService.java
@@ -59,6 +59,19 @@ public interface SetupService {
         createOidcApplication(propertySource, oidcAppName, orgUrl, groupClaimName, issuerUri, authorizationServerId, interactive, appType, redirectUris, Collections.emptyList());
     }
 
+    default void createOidcApplication(MutablePropertySource propertySource,
+                                       String oidcAppName,
+                                       String orgUrl,
+                                       String groupClaimName,
+                                       String issuerUri,
+                                       String authorizationServerId,
+                                       boolean interactive,
+                                       OpenIdConnectApplicationType appType,
+                                       List<String> redirectUris,
+                                       List<String> postLogoutRedirectUris) throws IOException {
+        createOidcApplication(propertySource, oidcAppName, orgUrl, groupClaimName, issuerUri, authorizationServerId, interactive, appType, redirectUris, postLogoutRedirectUris, Collections.emptyList());
+    }
+
     void createOidcApplication(MutablePropertySource propertySource,
                                String oidcAppName,
                                String orgUrl,
@@ -68,5 +81,6 @@ public interface SetupService {
                                boolean interactive,
                                OpenIdConnectApplicationType appType,
                                List<String> redirectUris,
+                               List<String> postLogoutRedirectUris,
                                List<String> trustedOrigins) throws IOException;
 }

--- a/common/src/test/groovy/com/okta/cli/common/URIsTest.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/URIsTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.cli.common
+
+
+import org.testng.annotations.Test
+
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.MatcherAssert.assertThat
+
+class URIsTest {
+
+    @Test
+    void reverseDomain() {
+        assertThat URIs.reverseDomain("http://example.com"), equalTo("com.example")
+        assertThat URIs.reverseDomain("https://foo.example.com"), equalTo("com.example.foo")
+        assertThat URIs.reverseDomain("foo.example.com"), equalTo("com.example.foo")
+        assertThat URIs.reverseDomain("ionic://foo.example.com"), equalTo("com.example.foo")
+    }
+
+    @Test
+    void baseUrl() {
+        assertThat URIs.baseUrlOf("http://example.com"), equalTo("http://example.com/")
+        assertThat URIs.baseUrlOf("http://example.com/foo/bar"), equalTo("http://example.com/")
+        assertThat URIs.baseUrlOf("ionic://foo.example.com"), equalTo("ionic://foo.example.com/")
+        assertThat URIs.baseUrlOf("com.example.foo:/callback"), equalTo("com.example.foo:/")
+    }
+}

--- a/common/src/test/groovy/com/okta/cli/common/model/FilterConfigBuilderTest.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/model/FilterConfigBuilderTest.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.cli.common.model
+
+
+import org.testng.annotations.Test
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.equalTo
+import static org.mockito.Mockito.spy
+import static org.mockito.Mockito.verify
+
+class FilterConfigBuilderTest {
+
+    @Test
+    void issuerTest() {
+        // setting the issuer should cascade and call setOrgUrl, and setReverseDomain
+        FilterConfigBuilder configBuilder = spy(new FilterConfigBuilder())
+        configBuilder.setIssuer("https://foobar.example.com/my/issuer")
+        def result = configBuilder.build()
+
+        assertThat result, equalTo([CLI_OKTA_ORG_URL: "https://foobar.example.com/",
+                                    CLI_OKTA_ISSUER: "https://foobar.example.com/my/issuer",
+                                    CLI_OKTA_REVERSE_DOMAIN: "com.example.foobar"])
+
+        verify(configBuilder).setOrgUrl("https://foobar.example.com/")
+        verify(configBuilder).setReverseDomain("com.example.foobar")
+    }
+}

--- a/common/src/test/groovy/com/okta/cli/common/service/DefaultSampleConfigParserTest.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/service/DefaultSampleConfigParserTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.cli.common.service
+
+import com.okta.cli.common.model.OktaSampleConfig
+import org.testng.annotations.Test
+
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.MatcherAssert.assertThat
+
+class DefaultSampleConfigParserTest {
+
+    @Test
+    void basicFilterTest() {
+
+        File file = File.createTempFile("basicFilterTest", "-sample.yaml")
+        file << "oauthClient:\n"
+        file << "  redirectUris:\n"
+        file << '    - ${CLI_OKTA_REVERSE_DOMAIN}.myApp://endpoint\n'
+        file << '    - http://example.com/foo\n'
+        file << '  applicationType: web\n'
+
+        OktaSampleConfig config = new DefaultSampleConfigParser().parseConfig(file, [CLI_OKTA_REVERSE_DOMAIN: "com.example.id"])
+        assertThat config.getOAuthClient().redirectUris, equalTo(["com.example.id.myApp://endpoint", "http://example.com/foo"])
+        assertThat config.getOAuthClient().getApplicationType(), equalTo("web")
+
+    }
+
+    @Test
+    void defaultsTest() {
+
+        File file = File.createTempFile("basicFilterTest", "-sample.yaml")
+        file << "oauthClient:\n"
+        file << "  redirectUris:\n"
+        file << '    - http://example.com/foo\n'
+
+        OktaSampleConfig config = new DefaultSampleConfigParser().parseConfig(file)
+        assertThat config.getOAuthClient().redirectUris, equalTo(["http://example.com/foo"])
+        assertThat config.getOAuthClient().getApplicationType(), equalTo("browser")
+
+    }
+}

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.cli</groupId>
         <artifactId>okta-cli-tools</artifactId>
-        <version>0.6.1-SNAPSHOT</version>
+        <version>0.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-cli-coverage</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.cli</groupId>
         <artifactId>okta-cli-tools</artifactId>
-        <version>0.6.1-SNAPSHOT</version>
+        <version>0.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-cli-its</artifactId>

--- a/integration-tests/src/test/groovy/com/okta/cli/test/AppsCreateIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/AppsCreateIT.groovy
@@ -51,6 +51,7 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
                     "",  // default of "test-project"
                     "2", // type of app choice "spa"
                     "",  // default callback "http://localhost:8080/callback"
+                    "",  // default post logout redirect
             ]
 
             def result = new CommandRunner()
@@ -59,6 +60,8 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
 
 
             assertThat result, resultMatches(0, allOf(
+                                                            containsString("Enter your Redirect URI [http://localhost:8080/callback]:"),
+                                                            containsString("Enter your Post Logout Redirect URI [http://localhost:8080/]:"),
                                                             containsString("Okta application configuration:"),
                                                             containsString("Client ID: test-id"),
                                                             containsString("Issuer:    ${mockWebServer.url("/")}/oauth2/test-as"),
@@ -95,6 +98,7 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
                     "",  // default of "test-project"
                     "3", //  "native" type of app choice
                     "",  // default callback "localhost:/callback"
+                    "",  // default post logout redirect localhost:/
             ]
 
             def result = new CommandRunner()
@@ -105,6 +109,8 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
             assertThat result, resultMatches(0, allOf(
                                                             containsString("Okta application configuration:"),
                                                             containsString("okta.oauth2.client-id: test-id"),
+                                                            containsString("Enter your Redirect URI [localhost:/callback]:"),
+                                                            containsString("Enter your Post Logout Redirect URI [localhost:/]:"),
                                                             containsString("okta.oauth2.issuer: ${mockWebServer.url("/")}/oauth2/test-as"),
                                                             not(containsString("okta.oauth2.client-secret"))),
                                                         null)
@@ -140,6 +146,7 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
                     "", //  default "web" type of app choice
                     "", // default of "test-project"
                     "", // default callback "http://localhost:8080/callback"
+                    "",  // default post logout redirect http://localhost:8080/
             ]
 
             def result = new CommandRunner()
@@ -149,6 +156,8 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
             assertThat result, resultMatches(0, allOf(
                                                             containsString("Created OIDC application, client-id: test-id"),
                                                             containsString("Okta application configuration has been written to"),
+                                                            containsString("Enter your Redirect URI [http://localhost:8080/callback]:"),
+                                                            containsString("Enter your Post Logout Redirect URI [http://localhost:8080/]:"),
                                                             containsString(".okta.env")),
                                                         null)
 
@@ -182,6 +191,7 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
                     "",  // default of "test-project"
                     "4", //  "native" type of app choice
                     "",  // default callback "localhost:/callback"
+                    "",  // default post logout redirect
             ]
 
             def result = new CommandRunner()
@@ -221,6 +231,7 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
                     "", //  default "web" type of app choice
                     "", // default of "test-project"
                     "", // default callback "http://localhost:8080/login/oauth2/code/okta"
+                    "",  // default post logout redirect
             ]
 
             def result = new CommandRunner()
@@ -230,6 +241,8 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
             assertThat result, resultMatches(0, allOf(
                                                             containsString("Created OIDC application, client-id: test-id"),
                                                             containsString("Okta application configuration has been written to"),
+                                                            containsString("Enter your Redirect URI [http://localhost:8080/login/oauth2/code/okta]:"),
+                                                            containsString("Enter your Post Logout Redirect URI [http://localhost:8080/]:"),
                                                             containsString("application.properties")),
                                                         null)
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.okta.cli</groupId>
     <artifactId>okta-cli-tools</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Okta CLI Tools</name>
@@ -73,19 +73,19 @@
             <dependency>
                 <groupId>com.okta.cli</groupId>
                 <artifactId>okta-cli-common</artifactId>
-                <version>0.6.1-SNAPSHOT</version>
+                <version>0.7.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.okta.cli</groupId>
                 <artifactId>okta-cli</artifactId>
-                <version>0.6.1-SNAPSHOT</version>
+                <version>0.7.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.okta.cli</groupId>
                 <artifactId>okta-cli-its</artifactId>
-                <version>0.6.1-SNAPSHOT</version>
+                <version>0.7.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
If not set this value defaults to the redirect URI base URLs
* Added basic validating parsing to protect against missing `oauthClient` nodes in the sample configuration
* adds `CLI_OKTA_REVERSE_DOMAIN` property
* Base URL and reverse domain property are available to use in `.okta/sample-config.yaml` files

This change also adds a prompt for the "Post Logout Redirect URI",  and defaults to `/` of the redirect URI
```diff
 Application name [foo]: foobar123
 Type of Application
 (The Okta CLI only supports a subset of application types and properties):
 > 1: Web
 > 2: Single Page App
 > 3: Native App (mobile)
 > 4: Service (Machine-to-Machine)
 Enter your choice [Web]: 1
 Type of Application
 > 1: Okta Spring Boot Starter
 > 2: Spring Boot
 > 3: JHipster
 > 4: Other
 Enter your choice [Other]: 1
 Redirect URI
 Common defaults:
  JHipster - http://localhost:8080/login/oauth2/code/oidc
  Spring Security - http://localhost:8080/login/oauth2/code/okta
 Enter your Redirect URI [http://localhost:8080/login/oauth2/code/okta]:
+ Enter your Post Logout Redirect URI [http://localhost:8080/]:
```
