### PR TITLE
Adds BaseCommand which all other commands extend from

### DIFF
--- a/cli/src/main/java/com/okta/cli/commands/BaseCommand.java
+++ b/cli/src/main/java/com/okta/cli/commands/BaseCommand.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.cli.commands;
+
+import com.okta.cli.Environment;
+import com.okta.cli.OktaCli;
+import com.okta.cli.console.ConsoleOutput;
+import com.okta.cli.console.Prompter;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+public abstract class BaseCommand implements Callable<Integer> {
+
+    @CommandLine.Mixin
+    private OktaCli.StandardOptions standardOptions;
+
+    public BaseCommand() {}
+
+    public BaseCommand(OktaCli.StandardOptions standardOptions) {
+        this.standardOptions = standardOptions;
+    }
+
+    protected abstract int runCommand() throws Exception;
+
+    @Override
+    public Integer call() throws Exception {
+        return runCommand();
+    }
+
+    protected OktaCli.StandardOptions getStandardOptions() {
+        return standardOptions;
+    }
+
+    protected ConsoleOutput getConsoleOutput() {
+        return standardOptions.getEnvironment().getConsoleOutput();
+    }
+
+    protected Prompter getPrompter() {
+        return standardOptions.getEnvironment().prompter();
+    }
+
+    protected Environment getEnvironment() {
+        return standardOptions.getEnvironment();
+    }
+}

--- a/cli/src/main/java/com/okta/cli/commands/Login.java
+++ b/cli/src/main/java/com/okta/cli/commands/Login.java
@@ -15,7 +15,6 @@
  */
 package com.okta.cli.commands;
 
-import com.okta.cli.OktaCli;
 import com.okta.cli.common.service.DefaultSdkConfigurationService;
 import com.okta.cli.common.service.SdkConfigurationService;
 import com.okta.cli.console.ConsoleOutput;
@@ -24,39 +23,34 @@ import com.okta.commons.lang.Strings;
 import com.okta.sdk.impl.config.ClientConfiguration;
 import picocli.CommandLine;
 
-import java.util.concurrent.Callable;
-
 @CommandLine.Command(name = "login",
         description = "Authorizes the Okta CLI tool")
-public class Login implements Callable<Integer> {
-
-    @CommandLine.Mixin
-    private OktaCli.StandardOptions standardOptions;
+public class Login extends BaseCommand {
 
     @Override
-    public Integer call() throws Exception {
+    public int runCommand() throws Exception {
 
         // check if okta client config exists?
         SdkConfigurationService sdkConfigurationService = new DefaultSdkConfigurationService();
         ClientConfiguration clientConfiguration = sdkConfigurationService.loadUnvalidatedConfiguration();
         String orgUrl = clientConfiguration.getBaseUrl();
 
-        ConsoleOutput out = standardOptions.getEnvironment().getConsoleOutput();
+        ConsoleOutput out = getConsoleOutput();
 
         if (Strings.isEmpty(orgUrl) || Strings.isEmpty(clientConfiguration.getApiToken())) {
 
             if (!Strings.isEmpty(orgUrl)) {
                 out.writeLine("Using Okta URL: " + orgUrl);
             } else {
-                orgUrl = standardOptions.getEnvironment().prompter().promptUntilValue(orgUrl, "Okta Org URL");
+                orgUrl = getPrompter().promptUntilValue(orgUrl, "Okta Org URL");
                 ConfigurationValidator.assertOrgUrl(orgUrl);
             }
 
             System.out.println("Enter your Okta API token, for more information see: https://bit.ly/get-okta-api-token");
-            String apiToken = standardOptions.getEnvironment().prompter().promptUntilValue(null, "Okta API token");
+            String apiToken = getPrompter().promptUntilValue(null, "Okta API token");
             ConfigurationValidator.assertApiToken(apiToken);
 
-            sdkConfigurationService.writeOktaYaml(orgUrl, apiToken, standardOptions.getEnvironment().getOktaPropsFile());
+            sdkConfigurationService.writeOktaYaml(orgUrl, apiToken, getEnvironment().getOktaPropsFile());
         } else {
             out.writeLine("Okta Org already configured: "+ orgUrl);
         }

--- a/cli/src/main/java/com/okta/cli/commands/Logs.java
+++ b/cli/src/main/java/com/okta/cli/commands/Logs.java
@@ -15,7 +15,6 @@
  */
 package com.okta.cli.commands;
 
-import com.okta.cli.OktaCli;
 import com.okta.cli.console.ConsoleOutput;
 import com.okta.commons.lang.Strings;
 import com.okta.sdk.client.Client;
@@ -32,26 +31,22 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
-import java.util.concurrent.Callable;
 
 import static java.lang.Thread.sleep;
 
 @CommandLine.Command(name = "logs",
                      description = "Lists Okta log events",
                      hidden = true)
-public class Logs implements Callable<Integer> {
-
-    @CommandLine.Mixin
-    private OktaCli.StandardOptions standardOptions;
+public class Logs extends BaseCommand {
 
     @CommandLine.Option(names = {"-f", "--follow"}, description = "Polls for new log events")
     protected boolean follow;
 
     @Override
-    public Integer call() throws Exception {
+    public int runCommand() throws Exception {
 
         Client client = Clients.builder().build();
-        ConsoleOutput output = standardOptions.getEnvironment().getConsoleOutput();
+        ConsoleOutput output = getConsoleOutput();
 
         // At most 1 hour back
         Instant since = Instant.now().minus(1, ChronoUnit.HOURS);

--- a/cli/src/main/java/com/okta/cli/commands/Register.java
+++ b/cli/src/main/java/com/okta/cli/commands/Register.java
@@ -27,14 +27,9 @@ import com.okta.cli.console.Prompter;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-import java.util.concurrent.Callable;
-
 @Command(name = "register",
          description = "Sign up for a new Okta account")
-public class Register implements Callable<Integer> {
-
-    @CommandLine.Mixin
-    protected OktaCli.StandardOptions standardOptions;
+public class Register extends BaseCommand {
 
     @CommandLine.Option(names = "--email", description = "Email used when registering a new Okta account")
     protected String email;
@@ -51,9 +46,10 @@ public class Register implements Callable<Integer> {
     public Register() {}
 
     private Register(OktaCli.StandardOptions standardOptions) {
-        this.standardOptions = standardOptions;
+        super(standardOptions);
     }
 
+    // TODO, these registration bit needs to be refactor out into a service, so that this stanardOptions object does NOT need to be passed around
     public static void requireRegistration(OktaCli.StandardOptions standardOptions) throws Exception {
         if (!new DefaultSdkConfigurationService().isConfigured()) {
             ConsoleOutput out = standardOptions.getEnvironment().getConsoleOutput();
@@ -68,20 +64,20 @@ public class Register implements Callable<Integer> {
     }
 
     @Override
-    public Integer call() throws Exception {
+    public int runCommand() throws Exception {
 
         CliRegistrationQuestions registrationQuestions = registrationQuestions();
 
         SetupService setupService = new DefaultSetupService(null);
         OrganizationResponse orgResponse = setupService.createOktaOrg(registrationQuestions,
-                                   standardOptions.getEnvironment().getOktaPropsFile(),
-                                   standardOptions.getEnvironment().isDemo(),
-                                   standardOptions.getEnvironment().isInteractive());
+                                   getEnvironment().getOktaPropsFile(),
+                                   getEnvironment().isDemo(),
+                                   getEnvironment().isInteractive());
 
         String identifier = orgResponse.getId();
         setupService.verifyOktaOrg(identifier,
                 registrationQuestions,
-                standardOptions.getEnvironment().getOktaPropsFile());
+                getEnvironment().getOktaPropsFile());
 
         return 0;
 
@@ -94,7 +90,7 @@ public class Register implements Callable<Integer> {
 
     private class CliRegistrationQuestions implements RegistrationQuestions {
 
-        private final Prompter prompter = standardOptions.getEnvironment().prompter();
+        private final Prompter prompter = getPrompter();
 
         @Override
         public boolean isOverwriteConfig() {

--- a/cli/src/main/java/com/okta/cli/commands/apps/Apps.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/Apps.java
@@ -15,30 +15,24 @@
  */
 package com.okta.cli.commands.apps;
 
-import com.okta.cli.OktaCli;
+import com.okta.cli.commands.BaseCommand;
 import com.okta.sdk.client.Clients;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
-
-import java.util.concurrent.Callable;
 
 @Command(name = "apps",
          description = "Manage Okta apps",
          subcommands = {
                     AppsConfig.class,
                     AppsCreate.class})
-public class Apps implements Callable<Integer> {
-
-    @CommandLine.Mixin
-    private OktaCli.StandardOptions standardOptions;
+public class Apps extends BaseCommand {
 
     @Override
-    public Integer call() throws Exception {
+    public int runCommand() throws Exception {
 
         Clients.builder().build()
                 .listApplications().stream()
                 .forEach(app -> {
-                    standardOptions.getEnvironment().getConsoleOutput().writeLine(app.getId() + "\t" + app.getLabel());
+                    getConsoleOutput().writeLine(app.getId() + "\t" + app.getLabel());
                 });
         return 0;
     }

--- a/cli/src/main/java/com/okta/cli/commands/apps/AppsConfig.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppsConfig.java
@@ -15,7 +15,7 @@
  */
 package com.okta.cli.commands.apps;
 
-import com.okta.cli.OktaCli;
+import com.okta.cli.commands.BaseCommand;
 import com.okta.cli.common.model.AuthorizationServer;
 import com.okta.cli.common.model.ClientCredentials;
 import com.okta.cli.console.ConsoleOutput;
@@ -27,24 +27,19 @@ import com.okta.sdk.resource.application.Application;
 import com.okta.sdk.resource.application.OpenIdConnectApplication;
 import picocli.CommandLine;
 
-import java.util.concurrent.Callable;
-
 @CommandLine.Command(name = "config",
         description = "Show an Okta app's configuration")
-public class AppsConfig implements Callable<Integer> {
-
-    @CommandLine.Mixin
-    private OktaCli.StandardOptions standardOptions;
+public class AppsConfig extends BaseCommand {
 
     @CommandLine.Option(names = "--app", description = "App ID", required = true)
     private String appName;
 
     @Override
-    public Integer call() {
+    public int runCommand() {
         Client client = Clients.builder().build();
         Application app = client.getApplication(appName);
 
-        ConsoleOutput out = standardOptions.getEnvironment().getConsoleOutput();
+        ConsoleOutput out = getConsoleOutput();
 
         Assert.isInstanceOf(OpenIdConnectApplication.class, app, "Existing application found with name '" +
                 appName +"' but it is NOT an OIDC application. Only OIDC applications work with the Okta CLI.");
@@ -52,7 +47,7 @@ public class AppsConfig implements Callable<Integer> {
         ClientCredentials clientCreds = new ClientCredentials(client.http()
                 .get("/api/v1/internal/apps/" + app.getId() + "/settings/clientcreds", ExtensibleResource.class));
 
-        AuthorizationServer authorizationServer = CommonAppsPrompts.getIssuer(client, standardOptions.getEnvironment().prompter(), null);
+        AuthorizationServer authorizationServer = CommonAppsPrompts.getIssuer(client, getPrompter(), null);
 
         out.writeLine("Name:          " + app.getLabel());
         out.writeLine("Client Id:     " + clientCreds.getClientId());

--- a/src/findbugs/findbugs-exclude.xml
+++ b/src/findbugs/findbugs-exclude.xml
@@ -16,7 +16,17 @@
 <FindBugsFilter>
 
     <Match>
+        <!-- These errors only contain local system info -->
+        <Or>
+            <Class name="com.okta.cli.OktaCli$ExceptionHandler"/>
+            <Class name="com.okta.cli.commands.BaseCommand"/>
+        </Or>
+        <Bug pattern="INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE"/>
+    </Match>
+    <Match>
+        <!-- These errors only contain local system info -->
         <Class name="com.okta.cli.OktaCli$ExceptionHandler"/>
+        <Class name="com.okta.cli.commands.BaseCommand"/>
         <Bug pattern="INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE"/>
     </Match>
 
@@ -63,7 +73,7 @@
     <Match>
         <!-- allows for user input -->
         <Class name="com.okta.cli.commands.Start"/>
-        <Method name="call"/>
+        <Method name="runCommand"/>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
     </Match>
 


### PR DESCRIPTION
* This helps hide the usage of the picocli mixin `OktaCli.StandardOptions` (which will make it easier to help abstract out the Picocli bits)
* Adds a single place where we can add cross cutting concerns, "you need to register first", "update the cli warnings", etc